### PR TITLE
fix: initial mix project check

### DIFF
--- a/lib/git_ops/changelog.ex
+++ b/lib/git_ops/changelog.ex
@@ -3,7 +3,7 @@ defmodule GitOps.Changelog do
   Functions for writing commits to the changelog, and initializing it.
   """
 
-  @spec write(String.t(), [GitOps.Commit.t()], String.t(), String.t(), Keyword.t()) :: :ok
+  @spec write(String.t(), [GitOps.Commit.t()], String.t(), String.t(), Keyword.t()) :: String.t()
   def write(path, commits, last_version, current_version, opts \\ []) do
     original_file_contents = File.read!(path)
 

--- a/lib/git_ops/config.ex
+++ b/lib/git_ops/config.ex
@@ -3,7 +3,7 @@ defmodule GitOps.Config do
   Helpers around fetching configurations, including setting defaults.
   """
 
-  def mix_project_check(opts) do
+  def mix_project_check(opts \\ []) do
     unless mix_project().project()[:version] do
       raise "mix_project must be configured in order to use git_ops. Please see the configuration in the README.md for an example."
     end

--- a/lib/git_ops/config.ex
+++ b/lib/git_ops/config.ex
@@ -3,14 +3,14 @@ defmodule GitOps.Config do
   Helpers around fetching configurations, including setting defaults.
   """
 
-  def mix_project_check(_env) do
+  def mix_project_check(opts) do
     unless mix_project().project()[:version] do
       raise "mix_project must be configured in order to use git_ops. Please see the configuration in the README.md for an example."
     end
 
     changelog_path = Path.expand(changelog_file())
 
-    unless File.exists?(changelog_path) do
+    unless opts[:initial] || File.exists?(changelog_path) do
       raise "\nFile: #{changelog_path} did not exist. Please use the `--initial` command to initialize."
     end
   end

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -53,10 +53,14 @@ defmodule Mix.Tasks.GitOps.Release do
     Semantic versioning uses this major version change to communicate, and it should not be
     reserved.
   """
-  @before_compile {GitOps.Config, :mix_project_check}
+  # @before_compile {GitOps.Config, :mix_project_check}
 
   @doc false
   def run(args) do
+    opts = get_opts(args)
+
+    GitOps.Config.mix_project_check(opts)
+
     changelog_file = GitOps.Config.changelog_file()
     changelog_path = Path.expand(changelog_file)
 
@@ -67,7 +71,7 @@ defmodule Mix.Tasks.GitOps.Release do
 
     repo = GitOps.Git.init!()
 
-    opts = get_opts(args)
+
 
     if opts[:initial] do
       GitOps.Changelog.initialize(changelog_path)

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -217,6 +217,7 @@ defmodule Mix.Tasks.GitOps.Release do
   end
 
   defp append_changes_to_message(message, _, {:error, :bad_replace}), do: message
+
   defp append_changes_to_message(message, file, changes) do
     message <> "----- BEGIN #{file} -----\n\n#{changes}\n----- END #{file} -----\n\n"
   end

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -53,7 +53,6 @@ defmodule Mix.Tasks.GitOps.Release do
     Semantic versioning uses this major version change to communicate, and it should not be
     reserved.
   """
-  # @before_compile {GitOps.Config, :mix_project_check}
 
   @doc false
   def run(args) do

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -71,8 +71,6 @@ defmodule Mix.Tasks.GitOps.Release do
 
     repo = GitOps.Git.init!()
 
-
-
     if opts[:initial] do
       GitOps.Changelog.initialize(changelog_path)
     end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -41,7 +41,7 @@ defmodule GitOps.Test.ConfigTest do
   end
 
   test "mix_project_check succeeds with initial flag but no changelog file" do
-    Config.mix_project_check([initial: true])
+    Config.mix_project_check(initial: true)
   end
 
   test "mix_project_check succeeds on valid project" do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -30,14 +30,18 @@ defmodule GitOps.Test.ConfigTest do
     Application.put_env(:git_ops, :mix_project, InvalidProject)
 
     assert_raise RuntimeError, ~r/mix_project must be configured/, fn ->
-      Config.mix_project_check(nil)
+      Config.mix_project_check()
     end
   end
 
   test "mix_project_check fails on invalid changelog" do
     assert_raise RuntimeError, ~r/File: .+ did not exist/, fn ->
-      Config.mix_project_check(nil)
+      Config.mix_project_check()
     end
+  end
+
+  test "mix_project_check succeeds with initial flag but no changelog file" do
+    Config.mix_project_check([initial: true])
   end
 
   test "mix_project_check succeeds on valid project" do

--- a/test/release_test.exs
+++ b/test/release_test.exs
@@ -17,7 +17,7 @@ defmodule GitOps.Mix.Tasks.Test.ReleaseTest do
     Application.put_env(:git_ops, :types, custom: [header: "Custom"], docs: [hidden?: false])
     Application.put_env(:git_ops, :version_tag_prefix, "v")
 
-    on_exit fn -> File.rm!(changelog) end
+    on_exit(fn -> File.rm!(changelog) end)
 
     %{changelog: changelog}
   end


### PR DESCRIPTION
Wanted to put this up so we have it since it is a crucial bug. Didn't know if it was possible to access the mix args in the `before_compile` step, so I moved it out, but if there is a way I'll put it change it.

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

