### PR TITLE
feat: dry_run release option

### DIFF
--- a/lib/git_ops/version_replace.ex
+++ b/lib/git_ops/version_replace.ex
@@ -3,19 +3,19 @@ defmodule GitOps.VersionReplace do
   Functions that handle the logic behind replacing the version in related files.
   """
 
-  @spec update_mix_project(module, String.t(), String.t()) :: :ok | {:error, :bad_replace}
-  def update_mix_project(mix_project, current_version, new_version) do
+  @spec update_mix_project(module, String.t(), String.t()) :: String.t() | {:error, :bad_replace}
+  def update_mix_project(mix_project, current_version, new_version, opts \\ []) do
     file = mix_project.module_info()[:compile][:source]
 
-    update_file(file, "@version \"#{current_version}\"", "@version \"#{new_version}\"")
+    update_file(file, "@version \"#{current_version}\"", "@version \"#{new_version}\"", opts)
   end
 
-  @spec update_readme(String.t(), String.t(), String.t()) :: :ok | {:error, :bad_replace}
-  def update_readme(readme, current_version, new_version) do
-    update_file(readme, ", \"~> #{current_version}\"", ", \"~> #{new_version}\"")
+  @spec update_readme(String.t(), String.t(), String.t()) :: String.t() | {:error, :bad_replace}
+  def update_readme(readme, current_version, new_version, opts \\ []) do
+    update_file(readme, ", \"~> #{current_version}\"", ", \"~> #{new_version}\"", opts)
   end
 
-  defp update_file(file, replace, pattern) do
+  defp update_file(file, replace, pattern, opts) do
     contents = File.read!(file)
 
     new_contents = String.replace(contents, replace, pattern)
@@ -23,9 +23,11 @@ defmodule GitOps.VersionReplace do
     if new_contents == contents do
       {:error, :bad_replace}
     else
-      File.write!(file, new_contents)
+      unless opts[:dry_run] do
+        File.write!(file, new_contents)
+      end
 
-      :ok
+      String.trim(new_contents, contents)
     end
   end
 end

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -112,7 +112,9 @@ defmodule Mix.Tasks.GitOps.Release do
 
     create_and_display_changes(current_version, new_version, changelog_changes, opts)
 
-    confirm_and_tag(repo, prefixed_new_version)
+    unless opts[:dry_run] do
+      confirm_and_tag(repo, prefixed_new_version, opts)
+    end
 
     :ok
   end
@@ -169,7 +171,7 @@ defmodule Mix.Tasks.GitOps.Release do
     end
   end
 
-  defp confirm_and_tag(repo, new_version) do
+  defp confirm_and_tag(repo, new_version, opts) do
     message = """
     Shall we commit and tag?
 

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.GitOps.Release do
     create_and_display_changes(current_version, new_version, changelog_changes, opts)
 
     unless opts[:dry_run] do
-      confirm_and_tag(repo, prefixed_new_version, opts)
+      confirm_and_tag(repo, prefixed_new_version)
     end
 
     :ok

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -114,8 +114,6 @@ defmodule Mix.Tasks.GitOps.Release do
 
     confirm_and_tag(repo, prefixed_new_version)
 
-    confirm_and_tag(repo, prefixed_new_version)
-
     :ok
   end
 

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -100,7 +100,8 @@ defmodule Mix.Tasks.GitOps.Release do
       end
 
     new_version = String.trim_leading(prefixed_new_version, prefix)
-
+    IO.inspect(current_version)
+    IO.inspect(new_version)
     changelog_changes =
       GitOps.Changelog.write(
         changelog_path,
@@ -215,6 +216,7 @@ defmodule Mix.Tasks.GitOps.Release do
     end
   end
 
+  defp append_changes_to_message(message, _, {:error, :bad_replace}), do: message
   defp append_changes_to_message(message, file, changes) do
     message <> "----- BEGIN #{file} -----\n\n#{changes}\n----- END #{file} -----\n\n"
   end

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -100,8 +100,7 @@ defmodule Mix.Tasks.GitOps.Release do
       end
 
     new_version = String.trim_leading(prefixed_new_version, prefix)
-    IO.inspect(current_version)
-    IO.inspect(new_version)
+
     changelog_changes =
       GitOps.Changelog.write(
         changelog_path,

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -171,7 +171,7 @@ defmodule Mix.Tasks.GitOps.Release do
     end
   end
 
-  defp confirm_and_tag(repo, new_version, opts) do
+  defp confirm_and_tag(repo, new_version) do
     message = """
     Shall we commit and tag?
 

--- a/test/changelog_test.exs
+++ b/test/changelog_test.exs
@@ -25,7 +25,7 @@ defmodule GitOps.Test.ChangelogTest do
       }
     ]
 
-    on_exit fn -> File.rm!(changelog) end
+    on_exit(fn -> File.rm!(changelog) end)
 
     %{changelog: changelog, commits: commits}
   end
@@ -65,7 +65,7 @@ defmodule GitOps.Test.ChangelogTest do
 
     original_contents = File.read!(changelog)
 
-    changes = Changelog.write(changelog, context.commits, "0.1.0", "0.2.0", [dry_run: true])
+    changes = Changelog.write(changelog, context.commits, "0.1.0", "0.2.0", dry_run: true)
 
     assert String.length(changes) > 0
 

--- a/test/release_test.exs
+++ b/test/release_test.exs
@@ -1,0 +1,30 @@
+# Suppress output of testing mix task
+Mix.shell(Mix.Shell.Process)
+
+defmodule GitOps.Mix.Tasks.Test.ReleaseTest do
+  use ExUnit.Case
+
+  alias Mix.Tasks.GitOps.Release
+
+  setup do
+    changelog = "TEST_CHANGELOG.md"
+
+    Application.put_env(:git_ops, :mix_project, GitOps.MixProject)
+    Application.put_env(:git_ops, :repository_url, "repo/url.git")
+    Application.put_env(:git_ops, :manage_mix_version?, true)
+    Application.put_env(:git_ops, :changelog_file, changelog)
+    Application.put_env(:git_ops, :manage_readme_version, true)
+    Application.put_env(:git_ops, :types, custom: [header: "Custom"], docs: [hidden?: false])
+    Application.put_env(:git_ops, :version_tag_prefix, "v")
+
+    on_exit fn -> File.rm!(changelog) end
+
+    %{changelog: changelog}
+  end
+
+  test "release with dry run works properly", context do
+    File.write!(context.changelog, "")
+
+    Release.run(["--dry-run", "--force-patch"])
+  end
+end

--- a/test/version_replace_test.exs
+++ b/test/version_replace_test.exs
@@ -44,7 +44,7 @@ defmodule GitOps.Test.VersionReplaceTest do
   test "that README changes are not written with dry_run", context do
     readme = context.readme
 
-    VersionReplace.update_readme(readme, "0.1.1", "1.0.0", [dry_run: true])
+    VersionReplace.update_readme(readme, "0.1.1", "1.0.0", dry_run: true)
 
     assert File.read!(readme) == readme_contents("1.0.0")
   end

--- a/test/version_replace_test.exs
+++ b/test/version_replace_test.exs
@@ -22,30 +22,36 @@ defmodule GitOps.Test.VersionReplaceTest do
     """
   end
 
-  setup_all do
+  setup do
     readme = "TEST_README.md"
-    readme_contents = readme_contents("0.1.1")
+    version = "0.1.1"
+
+    readme_contents = readme_contents(version)
 
     File.write!(readme, readme_contents)
 
     on_exit(fn -> File.rm!(readme) end)
 
-    %{readme: readme}
+    %{readme: readme, version: version}
   end
 
   test "that README gets written to properly", context do
     readme = context.readme
+    version = context.version
+    new_version = "1.0.0"
 
-    VersionReplace.update_readme(readme, "0.1.1", "1.0.0")
+    VersionReplace.update_readme(readme, version, new_version)
 
-    assert File.read!(readme) == readme_contents("1.0.0")
+    assert File.read!(readme) == readme_contents(new_version)
   end
 
   test "that README changes are not written with dry_run", context do
     readme = context.readme
+    version = context.version
+    new_version = "1.0.0"
 
-    VersionReplace.update_readme(readme, "0.1.1", "1.0.0", dry_run: true)
+    VersionReplace.update_readme(readme, version, new_version, dry_run: true)
 
-    assert File.read!(readme) == readme_contents("1.0.0")
+    assert File.read!(readme) == readme_contents(version)
   end
 end

--- a/test/version_replace_test.exs
+++ b/test/version_replace_test.exs
@@ -29,11 +29,22 @@ defmodule GitOps.Test.VersionReplaceTest do
     File.write!(readme, readme_contents)
 
     on_exit(fn -> File.rm!(readme) end)
+
+    %{readme: readme}
   end
 
-  test "that README gets written to properly" do
-    readme = "TEST_README.md"
+  test "that README gets written to properly", context do
+    readme = context.readme
+
     VersionReplace.update_readme(readme, "0.1.1", "1.0.0")
+
+    assert File.read!(readme) == readme_contents("1.0.0")
+  end
+
+  test "that README changes are not written with dry_run", context do
+    readme = context.readme
+
+    VersionReplace.update_readme(readme, "0.1.1", "1.0.0", [dry_run: true])
 
     assert File.read!(readme) == readme_contents("1.0.0")
   end


### PR DESCRIPTION
Dry run option: running `mix git_ops.release [--dry_run/-d]` runs the release without writing to files. The changes to the files are displayed. If the user wants to actually write and release, they must run `mix git_ops.release` and, optionally `Y` for committing and tagging.

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

