### PR TITLE
fix!: fail on prefixed `!` and support postfixed `!`

### DIFF
--- a/lib/git_ops/commit.ex
+++ b/lib/git_ops/commit.ex
@@ -19,7 +19,7 @@ defmodule GitOps.Commit do
   # 40/41 are `(` and `)`, but syntax highlighters don't like ?( and ?)
   type =
     optional(whitespace)
-    |> tag(ascii_string([not: ?:, not: 40, not: 41], min: 1), :type)
+    |> tag(ascii_string([not: ?:, not: ?!, not: 40, not: 41], min: 1), :type)
     |> optional(whitespace)
 
   scope =
@@ -35,9 +35,9 @@ defmodule GitOps.Commit do
 
   defparsecp(
     :commit,
-    optional(breaking_change_indicator)
-    |> concat(type)
+    type
     |> concat(optional(scope))
+    |> concat(optional(breaking_change_indicator))
     |> ignore(ascii_char([?:]))
     |> concat(message),
     inline: true

--- a/test/commit_test.exs
+++ b/test/commit_test.exs
@@ -23,8 +23,17 @@ defmodule GitOps.Test.CommitTest do
     assert parse!("feat: An awesome new feature!").message == "An awesome new feature!"
   end
 
-  test "a breaking change via exlamation mark is parsed as a breaking change" do
-    assert parse!("!feat: A breaking change").breaking?
+  @tag :regression
+  test "a breaking change via a prefixed exclamation mark fails to parse" do
+    assert Commit.parse("!feat: A breaking change") == :error
+  end
+
+  test "a breaking change via a postfixed exclamation mark is parsed as a breaking change" do
+    assert parse!("feat!: A breaking change").breaking?
+  end
+
+  test "a breaking change via a postfixed exclamation mark after a scope is parsed as a breaking change" do
+    assert parse!("feat(stuff)!: A breaking change").breaking?
   end
 
   test "a simple feature is formatted correctly" do
@@ -32,6 +41,6 @@ defmodule GitOps.Test.CommitTest do
   end
 
   test "a breaking change does not include the exclamation mark in the formatted version" do
-    assert format!("!feat: An awesome new feature!") == "* An awesome new feature!"
+    assert format!("feat!: An awesome new feature!") == "* An awesome new feature!"
   end
 end


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

