### PR TITLE
fix: Fix tag order from git tag function.

### DIFF
--- a/lib/git_ops/git.ex
+++ b/lib/git_ops/git.ex
@@ -48,7 +48,6 @@ defmodule GitOps.Git do
       repo
       |> Git.describe!(["--always", "--abbrev=0", "--tags"] ++ tags)
       |> String.split("\n", trim: true)
-      |> Enum.reject(fn tag -> Version.parse(tag) == :error end)
 
     if Enum.empty?(semver_tags) do
       raise """

--- a/lib/git_ops/version.ex
+++ b/lib/git_ops/version.ex
@@ -8,7 +8,6 @@ defmodule GitOps.Version do
   @spec last_valid_non_rc_version([String.t()], String.t()) :: String.t() | nil
   def last_valid_non_rc_version(versions, prefix) do
     versions
-    |> Enum.reverse()
     |> Enum.find(fn version ->
       match?({:ok, %{pre: []}}, parse(prefix, version))
     end)

--- a/lib/git_ops/version.ex
+++ b/lib/git_ops/version.ex
@@ -8,6 +8,7 @@ defmodule GitOps.Version do
   @spec last_valid_non_rc_version([String.t()], String.t()) :: String.t() | nil
   def last_valid_non_rc_version(versions, prefix) do
     versions
+    |> Enum.reject(fn tag -> parse(prefix, tag) == :error end)
     |> Enum.find(fn version ->
       match?({:ok, %{pre: []}}, parse(prefix, version))
     end)

--- a/test/version_test.exs
+++ b/test/version_test.exs
@@ -167,14 +167,14 @@ defmodule GitOps.Test.VersionTest do
   end
 
   test "last valid non rc is found correctly without prefixes" do
-    versions = ["0.0.1", "0.1.0-rc0", "0.1.0", "0.2.0-alpha"]
+    versions = ["0.2.0-alpha", "0.1.0", "0.1.0-rc0", "0.0.1"]
     last_rc = Version.last_valid_non_rc_version(versions, "")
 
     assert last_rc == "0.1.0"
   end
 
   test "last valid non rc is found correctly with prefixes" do
-    versions = ["v0.0.1", "v0.1.0-rc0", "0.1.0", "0.2.0-alpha"]
+    versions = ["0.2.0-alpha", "0.1.0", "v0.1.0-rc0", "v0.0.1"]
     last_rc = Version.last_valid_non_rc_version(versions, "v")
 
     assert last_rc == "v0.0.1"


### PR DESCRIPTION
This list of tags comes in ABC sorted according to git, whereas the
`last_valid_non_rc_version` function assumed it would come in tag
revision order. This manifests itself in finding e.g. 9.9.0 as the
latest revision when 10.0.0 is in the list of tags, as well. Because
this tag is used later to calculate the diff, it winds up double
counting commits and therefore doing bumps it should not be.