### PR TITLE
improvement: parse multiple messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ For an example, see this project's [CHANGELOG.md](https://github.com/zachdaniel/
 Roadmap (in no particular order):
 
 * More tests
-* Support multiple changes in a single commit via multiple conventional commits
-  in a single commit
 * Automatically parse issue numbers and github mentions into the correct format,
   linking the issue
 * A task to build a compliant commit

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -215,20 +215,26 @@ defmodule Mix.Tasks.GitOps.Release do
 
   defp parse_commit(text, config_types, log?) do
     case Commit.parse(text) do
-      {:ok, commit} ->
-        if Map.has_key?(config_types, String.downcase(commit.type)) do
-          [commit]
-        else
-          error_if_log("Commit with unknown type: #{text}", log?)
-
-          []
-        end
+      {:ok, commits} ->
+        commits_with_type(config_types, commits, text, log?)
 
       _ ->
         error_if_log("Unparseable commit: #{text}", log?)
 
         []
     end
+  end
+
+  defp commits_with_type(config_types, commits, text, log?) do
+    Enum.flat_map(commits, fn commit ->
+      if Map.has_key?(config_types, String.downcase(commit.type)) do
+        [commit]
+      else
+        error_if_log("Commit with unknown type in: #{text}", log?)
+
+        []
+      end
+    end)
   end
 
   defp append_changes_to_message(message, _, {:error, :bad_replace}), do: message

--- a/test/commit_test.exs
+++ b/test/commit_test.exs
@@ -3,24 +3,30 @@ defmodule GitOps.Test.CommitTest do
 
   alias GitOps.Commit
 
-  defp format!(message) do
+  defp format_one!(message) do
     message
-    |> parse!()
+    |> parse_one!()
     |> Commit.format()
   end
 
-  defp parse!(message) do
-    {:ok, commit} = Commit.parse(message)
+  defp parse_one!(message) do
+    {:ok, [commit]} = Commit.parse(message)
 
     commit
   end
 
+  defp parse_many!(message) do
+    {:ok, commits} = Commit.parse(message)
+
+    commits
+  end
+
   test "a simple feature is parsed with the correct type" do
-    assert parse!("feat: An awesome new feature!").type == "feat"
+    assert parse_one!("feat: An awesome new feature!").type == "feat"
   end
 
   test "a simple feature is parsed with the correct message" do
-    assert parse!("feat: An awesome new feature!").message == "An awesome new feature!"
+    assert parse_one!("feat: An awesome new feature!").message == "An awesome new feature!"
   end
 
   @tag :regression
@@ -29,18 +35,47 @@ defmodule GitOps.Test.CommitTest do
   end
 
   test "a breaking change via a postfixed exclamation mark is parsed as a breaking change" do
-    assert parse!("feat!: A breaking change").breaking?
+    assert parse_one!("feat!: A breaking change").breaking?
   end
 
   test "a breaking change via a postfixed exclamation mark after a scope is parsed as a breaking change" do
-    assert parse!("feat(stuff)!: A breaking change").breaking?
+    assert parse_one!("feat(stuff)!: A breaking change").breaking?
   end
 
   test "a simple feature is formatted correctly" do
-    assert format!("feat: An awesome new feature!") == "* An awesome new feature!"
+    assert format_one!("feat: An awesome new feature!") == "* An awesome new feature!"
   end
 
   test "a breaking change does not include the exclamation mark in the formatted version" do
-    assert format!("feat!: An awesome new feature!") == "* An awesome new feature!"
+    assert format_one!("feat!: An awesome new feature!") == "* An awesome new feature!"
+  end
+
+  test "multiple messages can be parsed from a commit" do
+    text = """
+    fix: fixed a bug
+
+    some text about it
+
+    some even more data about it
+
+    improvement: improved a thing
+
+    some other text about it
+
+    some even more text about it
+    """
+
+    assert [
+             %Commit{
+               message: "fixed a bug",
+               body: "some text about it",
+               footer: "some even more data about it"
+             },
+             %Commit{
+               message: "improved a thing",
+               body: "some other text about it",
+               footer: "some even more text about it"
+             }
+           ] = parse_many!(text)
   end
 end


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

