### PR TITLE
style: Fix credo warnings

### DIFF
--- a/lib/git_ops/git.ex
+++ b/lib/git_ops/git.ex
@@ -6,7 +6,7 @@ defmodule GitOps.Git do
   @default_githooks_path ".git/hooks"
 
   @spec init!() :: Git.Repository.t()
-  def init!() do
+  def init! do
     Git.init!(File.cwd!())
   end
 

--- a/test/message_hook_test.exs
+++ b/test/message_hook_test.exs
@@ -45,11 +45,12 @@ defmodule GitOps.Mix.Tasks.Test.MessageHookTest do
     assert File.exists?(commit_msg_hook_path)
     refute File.read!(commit_msg_hook_path) =~ ~S{mix git_ops.check_message "$@"}
 
-    assert_raise Mix.Error,
-                 ~r/The commit-msg hook `.*` does not call the Conventional Commits message validation task/,
-                 fn ->
-                   MessageHook.run(["--commit-msg-hook-path-override", commit_msg_hook_path])
-                 end
+    regex =
+      ~r/The commit-msg hook `.*` does not call the Conventional Commits message validation task/
+
+    assert_raise Mix.Error, regex, fn ->
+      MessageHook.run(["--commit-msg-hook-path-override", commit_msg_hook_path])
+    end
 
     assert File.exists?(commit_msg_hook_path)
     assert initial_content == File.read!(commit_msg_hook_path)


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

