### PR TITLE
feat(project_info_dotenv_format): Add the `dotenv` format for project_info output.

### DIFF
--- a/lib/mix/tasks/git_ops.project_info.ex
+++ b/lib/mix/tasks/git_ops.project_info.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.GitOps.ProjectInfo do
   ## Switches:
 
   * `--format|-f` selects the output format. Currently suported output formats
-    are `json`, `toml`, `github-actions` and `shell`.
+    are `json`, `toml`, `github-actions`, `shell` and `dotenv`.
   """
 
   alias GitOps.Config
@@ -30,6 +30,7 @@ defmodule Mix.Tasks.GitOps.ProjectInfo do
 
     opts
     |> Keyword.get(:format)
+    |> String.downcase()
     |> case do
       "toml" ->
         format_toml(project, opts)
@@ -43,8 +44,11 @@ defmodule Mix.Tasks.GitOps.ProjectInfo do
       "shell" ->
         format_shell(project, opts)
 
+      "dotenv" ->
+        format_dotenv(project, opts)
+
       format ->
-        raise "Invalid format `#{inspect(format)}`.  Valid formats are `json`, `toml`, `github-actions` and `shell`."
+        raise "Invalid format `#{inspect(format)}`.  Valid formats are `json`, `toml`, `github-actions`, `shell` and `dotenv`."
     end
   end
 
@@ -79,6 +83,12 @@ defmodule Mix.Tasks.GitOps.ProjectInfo do
     {name, version} = extract_name_and_version_from_project(project)
 
     IO.write(~s|export APP_NAME="#{name}"\nexport APP_VERSION="#{version}"\n|)
+  end
+
+  defp format_dotenv(project, _opts) do
+    {name, version} = extract_name_and_version_from_project(project)
+
+    IO.write(~s|APP_NAME="#{name}"\nAPP_VERSION="#{version}"\n|)
   end
 
   defp extract_name_and_version_from_project(project) do

--- a/test/project_info_test.exs
+++ b/test/project_info_test.exs
@@ -47,7 +47,7 @@ defmodule GitOps.Mix.Tasks.Test.ProjectInfoTest do
     end
   end
 
-  describe "Github Actions actual format" do
+  describe "Github Actions format" do
     test "it is correctly formatted", %{name: name, version: version} do
       actual = run(["--format", "github-actions"])
 
@@ -60,13 +60,26 @@ defmodule GitOps.Mix.Tasks.Test.ProjectInfoTest do
     end
   end
 
-  describe "Shell actual format" do
+  describe "Shell format" do
     test "it is correctly formatted", %{name: name, version: version} do
       actual = run(["--format", "shell"])
 
       expected = """
       export APP_NAME="#{name}"
       export APP_VERSION="#{version}"
+      """
+
+      assert actual == expected
+    end
+  end
+
+  describe "Dotenv format" do
+    test "it is correctly formatted", %{name: name, version: version} do
+      actual = run(["--format", "dotenv"])
+
+      expected = """
+      APP_NAME="#{name}"
+      APP_VERSION="#{version}"
       """
 
       assert actual == expected


### PR DESCRIPTION
This is handy because you can use `dotenv` files to share outputs between jobs on Gitlab CI.

### Contributor checklist
- [X] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [X] Features include unit/acceptance tests

