### PR TITLE
feat: Include changelog notes to release tag message

### DIFF
--- a/lib/git_ops/changelog.ex
+++ b/lib/git_ops/changelog.ex
@@ -56,15 +56,20 @@ defmodule GitOps.Changelog do
         ["## ", current_version, " ", date]
       end
 
-    new_contents =
+    new_message =
       IO.iodata_to_binary([
-        String.trim(head),
-        "\n\n<!-- changelog -->\n\n",
         version_header,
         "\n",
         breaking_changes_contents,
         "\n\n",
-        contents_to_insert,
+        contents_to_insert
+      ])
+
+    new_contents =
+      IO.iodata_to_binary([
+        String.trim(head),
+        "\n\n<!-- changelog -->\n\n",
+        new_message,
         rest
       ])
 
@@ -72,7 +77,7 @@ defmodule GitOps.Changelog do
       File.write!(path, new_contents)
     end
 
-    String.trim(original_file_contents, new_contents)
+    String.trim(new_message)
   end
 
   @spec initialize(String.t(), Keyword.t()) :: :ok

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -135,11 +135,11 @@ defmodule Mix.Tasks.GitOps.Release do
         :ok
 
       opts[:yes] ->
-        tag(repo, changelog_file, prefixed_new_version)
+        tag(repo, changelog_file, prefixed_new_version, changelog_changes)
         :ok
 
       true ->
-        confirm_and_tag(repo, changelog_file, prefixed_new_version)
+        confirm_and_tag(repo, changelog_file, prefixed_new_version, changelog_changes)
         :ok
     end
   end
@@ -195,15 +195,15 @@ defmodule Mix.Tasks.GitOps.Release do
     end
   end
 
-  defp tag(repo, changelog_file, new_version) do
+  defp tag(repo, changelog_file, new_version, new_message) do
     Git.add!(repo, "#{changelog_file}")
     Git.commit!(repo, ["-am", "chore: release version #{new_version}"])
-    Git.tag!(repo, ["-a", new_version, "-m", "release #{new_version}"])
+    Git.tag!(repo, ["-a", new_version, "-m", new_message])
 
     Mix.shell().info("Don't forget to push with tags:\n\n    git push --follow-tags")
   end
 
-  defp confirm_and_tag(repo, changelog_file, new_version) do
+  defp confirm_and_tag(repo, changelog_file, new_version, new_message) do
     message = """
     Shall we commit and tag?
 
@@ -211,7 +211,7 @@ defmodule Mix.Tasks.GitOps.Release do
     """
 
     if Mix.shell().yes?(message) do
-      tag(repo, changelog_file, new_version)
+      tag(repo, changelog_file, new_version, new_message)
     else
       Mix.shell().info("""
       If you want to do it on your own, make sure you tag the release with:


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Features include unit/acceptance tests

This is a first attempt at implementing #43.

A few notes:
- I'm not sure if we may need to think about escaping anything in the message we're passing to `Git.tag!/2`
- In the `confirm_and_tag/4` function, it prints out a message if you choose the "no" path, and in there I figured it would be too verbose to include the expanded release notes, so I kept the old "release [version]" format for that message.
- I didn't add any tests for this, not sure what we would want to test in this case since we're just changing the content of the message. Existing tests are passing.

I'm happy to address any shortcomings in my implementation.