### PR TITLE
feat: add a --ci option

### DIFF
--- a/lib/git_ops/version.ex
+++ b/lib/git_ops/version.ex
@@ -16,7 +16,6 @@ defmodule GitOps.Version do
 
   def determine_new_version(current_version, prefix, commits, opts) do
     parsed = parse!(prefix, prefix <> current_version)
-
     rc? = opts[:rc]
 
     build = opts[:build]
@@ -24,7 +23,7 @@ defmodule GitOps.Version do
     new_version = new_version(commits, parsed, rc?, opts)
 
     if versions_equal?(new_version, parsed) && build == parsed.build do
-      raise """
+      message = """
       No changes should result in a new release version.
 
       Options:
@@ -38,6 +37,8 @@ defmodule GitOps.Version do
       * You can add build metadata using `--build` that will signify that something was
         unique about this build.
       """
+
+      maybe_raise(message, opts)
     end
 
     unprefixed =
@@ -137,6 +138,14 @@ defmodule GitOps.Version do
 
       :error ->
         raise ArgumentError, "Expected: #{text} to be parseable as a version, but it was not."
+    end
+  end
+
+  defp maybe_raise(msg, opts) do
+    if Keyword.fetch(opts, :ci) == {:ok, true} do
+      IO.puts(msg)
+    else
+      raise msg
     end
   end
 end

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -56,6 +56,8 @@ defmodule Mix.Tasks.GitOps.Release do
   * `--dry-run` - Allow users to run release process and view changes without committing and tagging
 
   * `--yes` - Don't prompt for confirmation, just perform release.  Useful for your CI run.
+
+  * `--ci` - Do not raise an exception when there is no version to bump. Useful for CI pipelines.
   """
 
   alias GitOps.Changelog
@@ -289,7 +291,8 @@ defmodule Mix.Tasks.GitOps.Release do
           pre_release: :string,
           rc: :boolean,
           dry_run: :boolean,
-          yes: :boolean
+          yes: :boolean,
+          ci: :boolean
         ],
         aliases: [
           i: :initial,

--- a/test/version_test.exs
+++ b/test/version_test.exs
@@ -1,5 +1,6 @@
 defmodule GitOps.Test.VersionTest do
   use ExUnit.Case
+  import ExUnit.CaptureIO
 
   alias GitOps.Version
 
@@ -62,6 +63,26 @@ defmodule GitOps.Test.VersionTest do
     assert_raise RuntimeError, ~r/No changes should result in a new release version./, fn ->
       new_version("0.1.1", [chore()])
     end
+  end
+
+  test "attempting to release when no commit would yield a new version number with the --ci option is not an error" do
+    message = """
+    No changes should result in a new release version.
+
+    Options:
+
+    * If no fixes or features were added, then perhaps you don't need to release.
+    * If a fix or feature commit was not correctly annotated, you could alter your git
+      history to fix it and run this command again, or create an empty commit via
+      `git commit --allow-empty` that contains an appropriate message.
+    * If you don't care and want a new version, you can use `--force-patch` which
+      will update the patch version regardless.
+    * You can add build metadata using `--build` that will signify that something was
+      unique about this build.
+
+    """
+
+    assert capture_io(fn -> new_version("0.1.1", [chore()], ci: true) end) == message
   end
 
   test "if changing the build metadata, a non-version change is not an error" do


### PR DESCRIPTION
## Description
This PR adds a --ci option to the `mix git_ops.release` task. as a result there will not be an exception to be raised when there is no version to build. This should felp people with CI pipelines that make releases for them.

### Usage

In your CI job:

```
mix git_ops.release --ci --yes
```

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Features include unit/acceptance tests

closes #48