### PR TITLE
feat: enable custom replace/pattern for readme versioning

### DIFF
--- a/lib/git_ops/version_replace.ex
+++ b/lib/git_ops/version_replace.ex
@@ -10,8 +10,20 @@ defmodule GitOps.VersionReplace do
     update_file(file, "@version \"#{current_version}\"", "@version \"#{new_version}\"", opts)
   end
 
-  @spec update_readme(String.t(), String.t(), String.t()) :: String.t() | {:error, :bad_replace}
-  def update_readme(readme, current_version, new_version, opts \\ []) do
+  @spec update_readme(
+          String.t()
+          | {String.t(), fun :: (String.t() -> String.t()), fun :: (String.t() -> String.t())},
+          String.t(),
+          String.t()
+        ) :: String.t() | {:error, :bad_replace}
+  def update_readme(readme, current_version, new_version, opts \\ [])
+
+  def update_readme({readme, replace, pattern}, current_version, new_version, opts)
+      when is_function(replace, 1) and is_function(pattern, 1) do
+    update_file(readme, replace.(current_version), pattern.(new_version), opts)
+  end
+
+  def update_readme(readme, current_version, new_version, opts) do
     update_file(readme, ", \"~> #{current_version}\"", ", \"~> #{new_version}\"", opts)
   end
 


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

