### PR TITLE
fix: Update deprecated `set-output` format for GitHub Actions to use environment variables

### DIFF
--- a/lib/mix/tasks/git_ops.project_info.ex
+++ b/lib/mix/tasks/git_ops.project_info.ex
@@ -76,9 +76,8 @@ defmodule Mix.Tasks.GitOps.ProjectInfo do
   defp format_github_actions(project, _opts) do
     {name, version} = extract_name_and_version_from_project(project)
 
-    IO.write(
-      "echo \"app_name=#{name}\" >> $GITHUB_OUTPUT\necho \"app_version=#{version}\" >> $GITHUB_OUTPUT\n"
-    )
+    System.fetch_env!("GITHUB_OUTPUT")
+    |> File.write("app_name=#{name}\napp_version=#{version}\n", [:append])
   end
 
   defp format_shell(project, _opts) do

--- a/lib/mix/tasks/git_ops.project_info.ex
+++ b/lib/mix/tasks/git_ops.project_info.ex
@@ -76,7 +76,9 @@ defmodule Mix.Tasks.GitOps.ProjectInfo do
   defp format_github_actions(project, _opts) do
     {name, version} = extract_name_and_version_from_project(project)
 
-    IO.write("::set-output name=app_name::#{name}\n::set-output name=app_version::#{version}\n")
+    IO.write(
+      "echo \"app_name=#{name}\" >> $GITHUB_OUTPUT\necho \"app_version=#{version}\" >> $GITHUB_OUTPUT\n"
+    )
   end
 
   defp format_shell(project, _opts) do

--- a/test/project_info_test.exs
+++ b/test/project_info_test.exs
@@ -52,8 +52,8 @@ defmodule GitOps.Mix.Tasks.Test.ProjectInfoTest do
       actual = run(["--format", "github-actions"])
 
       expected = """
-      ::set-output name=app_name::#{name}
-      ::set-output name=app_version::#{version}
+      echo "app_name=#{name}" >> $GITHUB_OUTPUT
+      echo "app_version=#{version}" >> $GITHUB_OUTPUT
       """
 
       assert actual == expected

--- a/test/project_info_test.exs
+++ b/test/project_info_test.exs
@@ -48,15 +48,22 @@ defmodule GitOps.Mix.Tasks.Test.ProjectInfoTest do
   end
 
   describe "Github Actions format" do
-    test "it is correctly formatted", %{name: name, version: version} do
-      actual = run(["--format", "github-actions"])
+    test "it correctly formats data to the ENV file", %{name: name, version: version} do
+      file = "#{System.tmp_dir()}/test_github_actions_format"
+      System.put_env("GITHUB_OUTPUT", file)
+
+      run(["--format", "github-actions"])
+
+      actual = File.read!(file)
 
       expected = """
-      echo "app_name=#{name}" >> $GITHUB_OUTPUT
-      echo "app_version=#{version}" >> $GITHUB_OUTPUT
+      app_name=#{name}
+      app_version=#{version}
       """
 
       assert actual == expected
+
+      on_exit(fn -> File.rm!(file) end)
     end
   end
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more details

Closes #60

(Note: I have merely proved it correct, not tried it)

### Contributor checklist

- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

