### PR TITLE
chore(README): Remove Ebert badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Build Status](https://travis-ci.com/zachdaniel/git_ops.svg?branch=master)](https://travis-ci.com/zachdaniel/git_ops)
 [![Inline docs](http://inch-ci.org/github/zachdaniel/git_ops.svg?branch=master)](http://inch-ci.org/github/zachdaniel/git_ops)
 [![Coverage Status](https://coveralls.io/repos/github/zachdaniel/git_ops/badge.svg?branch=master)](https://coveralls.io/github/zachdaniel/git_ops?branch=master)
-[![Ebert](https://ebertapp.io/github/zachdaniel/git_ops.svg)](https://ebertapp.io/github/zachdaniel/git_ops)
 
 A small tool to help generate changelogs from conventional commit messages.
 For more information, see [conventional


### PR DESCRIPTION
Unfortunately, Ebert (now SourceLevel) doesn't provide this badge anymore.

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

