### PR TITLE
improvement: Enable `git_ops.check_message` to check the latest commit message.

### DIFF
--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -10,7 +10,7 @@ defmodule GitOps.Test.ConfigTest do
     Application.put_env(:git_ops, :changelog_file, "CUSTOM_CHANGELOG.md")
     Application.put_env(:git_ops, :manage_readme_version, true)
     Application.put_env(:git_ops, :types, custom: [header: "Custom"], docs: [hidden?: false])
-    Application.put_env(:git_ops, :tags, [allowed: ["tag_1", "tag_2"], allow_untagged?: false])
+    Application.put_env(:git_ops, :tags, allowed: ["tag_1", "tag_2"], allow_untagged?: false)
     Application.put_env(:git_ops, :version_tag_prefix, "v")
   end
 


### PR DESCRIPTION
### Contributor checklist
- [X] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [X] Features include unit/acceptance tests

