### PR TITLE
improvement: add types to project.info (#69)

### DIFF
--- a/lib/git_ops/config.ex
+++ b/lib/git_ops/config.ex
@@ -89,6 +89,14 @@ defmodule GitOps.Config do
     end)
   end
 
+  def type_keys do
+    types()
+    |> Map.keys()
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.join(" ")
+  end
+
   def allowed_tags, do: :git_ops |> Application.get_env(:tags, []) |> Keyword.get(:allowed, :any)
 
   def allow_untagged?,


### PR DESCRIPTION
Emit list of types in "mix git_ops.project_info"

The type information may be useful for CI.

See Issue #69 for more info.

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

