### PR TITLE
Feat: pr links in changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Roadmap (in no particular order):
 - Automatically parse issue numbers and github mentions into the correct format, linking the issue
 - A task to build a compliant commit
 - Validation of commits
-- Automatically link to the PR that merged a given commit in the changelog
 - A hundred other things I forgot to write down while writing the initial version
 
 Important addendums:
@@ -73,6 +72,7 @@ config :git_ops,
   # if set to true, this uses git user.email to lookup user on github and insert the handle in release notes
   # otherwise it uses the author name as provided in the commit
   github_handle_lookup?: true,
+  github_api_base_url: "https://api.github.com",
   
   repository_url: "https://github.com/my_user/my_repo",
   types: [

--- a/lib/git_ops/config.ex
+++ b/lib/git_ops/config.ex
@@ -62,8 +62,9 @@ defmodule GitOps.Config do
   def manage_mix_version?, do: truthy?(Application.get_env(:git_ops, :manage_mix_version?))
 
   @doc """
-  Returns whether GitHub handle lookup is enabled for contributors.
-  When enabled, the system will attempt to find GitHub usernames for commit authors.
+  Returns whether GitHub integrations are enabled.
+
+  When enabled, the system will attempt to find GitHub usernames for commit authors and pull request information.
   When disabled or if lookup fails, it will use the author's name directly.
   """
   def github_handle_lookup?, do: truthy?(Application.get_env(:git_ops, :github_handle_lookup?))

--- a/lib/git_ops/config.ex
+++ b/lib/git_ops/config.ex
@@ -69,6 +69,12 @@ defmodule GitOps.Config do
   """
   def github_handle_lookup?, do: truthy?(Application.get_env(:git_ops, :github_handle_lookup?))
 
+  @doc """
+  Returns the base URL for the GitHub API. Override this if you are using a self-hosted GitHub instance.
+  """
+  def github_api_base_url,
+    do: Application.get_env(:git_ops, :github_api_base_url) || "https://api.github.com"
+
   def manage_readme_version do
     case Application.get_env(:git_ops, :manage_readme_version) do
       true ->

--- a/lib/git_ops/git.ex
+++ b/lib/git_ops/git.ex
@@ -37,6 +37,21 @@ defmodule GitOps.Git do
     ["chore(GitOps): Add changelog using git_ops." | messages]
   end
 
+  @spec get_commit_hashes(Git.Repository.t(), String.t() | :all) :: [String.t()]
+  def get_commit_hashes(repo, since_tag \\ :all) do
+    log_args =
+      case since_tag do
+        :all -> ["--format=%H--gitops--"]
+        tag -> ["#{tag}..HEAD", "--format=%H--gitops--"]
+      end
+
+    repo
+    |> Git.log!(log_args)
+    |> String.split("--gitops--")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&Kernel.==(&1, ""))
+  end
+
   @spec tags(Git.Repository.t()) :: [String.t()]
   def tags(repo) do
     tags =

--- a/lib/git_ops/github.ex
+++ b/lib/git_ops/github.ex
@@ -17,6 +17,17 @@ defmodule GitOps.GitHub do
     |> Map.new()
   end
 
+  def batch_pull_requests_from_commits(hashes) when is_list(hashes) do
+    hashes
+    |> Task.async_stream(&get_pull_request_from_commit/1,
+      timeout: 30_000,
+      max_concurrency: 5
+    )
+    |> Enum.zip(hashes)
+    |> Enum.map(fn {{:ok, result}, hash} -> {hash, result} end)
+    |> Map.new()
+  end
+
   @doc """
   Find a GitHub user by their email address.
   Returns {:ok, user} if found, where user contains :username, :id, and :url.
@@ -26,14 +37,8 @@ defmodule GitOps.GitHub do
     Application.ensure_all_started(:req)
 
     if email do
-      headers = %{
-        "accept" => "application/vnd.github.v3+json",
-        "user-agent" => "Elixir.GitOps",
-        "X-GitHub-Api-Version" => "2022-11-28"
-      }
-
       case Req.get("https://api.github.com/search/users",
-             headers: headers,
+             headers: github_headers(),
              params: [q: "#{email} in:email", per_page: 2]
            ) do
         {:ok, %Req.Response{status: 200, body: %{"items" => [first_user | _]}}} ->
@@ -57,5 +62,42 @@ defmodule GitOps.GitHub do
   rescue
     error ->
       {:error, "Error making GitHub API request: #{inspect(error)}"}
+  end
+
+  @spec get_pull_request_from_commit(String.t()) ::
+          {:ok, %{number: integer(), url: String.t()} | nil} | {:error, String.t()}
+
+  def get_pull_request_from_commit(hash) do
+    case Req.get(
+           "https://api.github.com/repos/#{repo_owner_and_name()}/commits/#{hash}/pulls",
+           headers: github_headers()
+         ) do
+      {:ok, %Req.Response{status: 200, body: [first_pr | _]}} ->
+        {:ok, %{number: first_pr["number"], url: first_pr["html_url"]}}
+
+      {:ok, %Req.Response{status: 200, body: []}} ->
+        {:ok, nil}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, "GitHub API request failed with status #{status}: #{inspect(body)}"}
+
+      {:error, reason} ->
+        {:error, "Error making GitHub API request: #{inspect(reason)}"}
+    end
+  end
+
+  defp repo_owner_and_name() do
+    GitOps.Config.repository_url()
+    |> String.split("/")
+    |> Enum.take(-2)
+    |> Enum.join("/")
+  end
+
+  defp github_headers do
+    %{
+      "accept" => "application/vnd.github.v3+json",
+      "user-agent" => "Elixir.GitOps",
+      "X-GitHub-Api-Version" => "2022-11-28"
+    }
   end
 end

--- a/lib/git_ops/github.ex
+++ b/lib/git_ops/github.ex
@@ -37,7 +37,7 @@ defmodule GitOps.GitHub do
     Application.ensure_all_started(:req)
 
     if email do
-      case Req.get("https://api.github.com/search/users",
+      case Req.get("#{GitOps.Config.github_api_base_url()}/search/users",
              headers: github_headers(),
              params: [q: "#{email} in:email", per_page: 2]
            ) do
@@ -69,7 +69,7 @@ defmodule GitOps.GitHub do
 
   def get_pull_request_from_commit(hash) do
     case Req.get(
-           "https://api.github.com/repos/#{repo_owner_and_name()}/commits/#{hash}/pulls",
+           "#{GitOps.Config.github_api_base_url()}/repos/#{repo_owner_and_name()}/commits/#{hash}/pulls",
            headers: github_headers()
          ) do
       {:ok, %Req.Response{status: 200, body: [first_pr | _]}} ->

--- a/test/commit_test.exs
+++ b/test/commit_test.exs
@@ -150,4 +150,31 @@ defmodule GitOps.Test.CommitTest do
 
     assert Commit.format(commit) == "* add new feature"
   end
+
+  test "formats commit with PR information" do
+    commit = %Commit{
+      type: "feat",
+      message: "add new feature",
+      pr_info: %{number: 123, url: "https://github.com/johndoe/repo/pull/123"}
+    }
+
+    assert Commit.format(commit) ==
+             "* add new feature [(#123)](https://github.com/johndoe/repo/pull/123)"
+  end
+
+  test "formats commit with PR information and author information" do
+    commit = %Commit{
+      type: "feat",
+      message: "add new feature",
+      author_name: "John Doe",
+      author_email: "john.doe@example.com",
+      github_user_data: %{
+        username: "johndoe"
+      },
+      pr_info: %{number: 123, url: "https://github.com/johndoe/repo/pull/123"}
+    }
+
+    assert Commit.format(commit) ==
+             "* add new feature by @johndoe [(#123)](https://github.com/johndoe/repo/pull/123)"
+  end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -12,6 +12,7 @@ defmodule GitOps.Test.ConfigTest do
     Application.put_env(:git_ops, :types, custom: [header: "Custom"], docs: [hidden?: false])
     Application.put_env(:git_ops, :tags, allowed: ["tag_1", "tag_2"], allow_untagged?: false)
     Application.put_env(:git_ops, :version_tag_prefix, "v")
+    Application.put_env(:git_ops, :github_api_base_url, "https://api.company.github.com")
   end
 
   test "mix_project returns correctly" do
@@ -114,6 +115,12 @@ defmodule GitOps.Test.ConfigTest do
 
   test "custom prefixes returns correctly" do
     assert Config.prefix() == "v"
+  end
+
+  test "Github API base url returns correctly" do
+    assert Config.github_api_base_url() == "https://api.company.github.com"
+    Application.delete_env(:git_ops, :github_api_base_url)
+    assert Config.github_api_base_url() == "https://api.github.com"
   end
 end
 

--- a/test/git_test.exs
+++ b/test/git_test.exs
@@ -1,0 +1,53 @@
+defmodule GitOps.Test.GitTest do
+  use ExUnit.Case
+
+  alias GitOps.Git
+
+  describe "parse_git_log/1" do
+    test "parses commits" do
+      git_log_output = """
+      075380d3dc81e80b37d02195184a784b0c0dd7a7--hash--chore: release version v2.8.0
+      --message--Zach Daniel--author--zach@zachdaniel.dev--gitops--
+      29f5b4ee1a9360902c43d5c2ce78c409e2c6e909--hash--chore: fix previous commit, store user_data
+      --message--Zach Daniel--author--zach@zachdaniel.dev--gitops--
+      91140d2393eb9d7462b4da4fa5439645ee0b8aa9--hash--chore: use `Req` and make references use usernames
+      --message--Zach Daniel--author--zach@zachdaniel.dev--gitops--
+      """
+
+      result = Git.parse_git_log(git_log_output)
+
+      assert length(result) == 3
+
+      assert Enum.at(result, 0) == %{
+               hash: "075380d3dc81e80b37d02195184a784b0c0dd7a7",
+               message: "chore: release version v2.8.0",
+               author_name: "Zach Daniel",
+               author_email: "zach@zachdaniel.dev"
+             }
+
+      assert Enum.at(result, 1) == %{
+               hash: "29f5b4ee1a9360902c43d5c2ce78c409e2c6e909",
+               message: "chore: fix previous commit, store user_data",
+               author_name: "Zach Daniel",
+               author_email: "zach@zachdaniel.dev"
+             }
+
+      assert Enum.at(result, 2) == %{
+               hash: "91140d2393eb9d7462b4da4fa5439645ee0b8aa9",
+               message: "chore: use `Req` and make references use usernames",
+               author_name: "Zach Daniel",
+               author_email: "zach@zachdaniel.dev"
+             }
+    end
+
+    test "handles empty git log output" do
+      result = Git.parse_git_log("")
+      assert result == []
+    end
+
+    test "handles git log output with only separators" do
+      result = Git.parse_git_log("--gitops----gitops--")
+      assert result == []
+    end
+  end
+end


### PR DESCRIPTION
This change adds two new features:
- the ability to link to GitHub Pull requests in the changelog
- the ability to use the GitHub integrations on a private instance of GitHub (i.e. enterprise)

It also contains a commit that batches the multiple `git log` calls going on using a combined format containing each piece of commit metadata we care about.

### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

