### PR TITLE
fix: abort release when previous version tag is not fetched locally

### DIFF
--- a/lib/git_ops/git.ex
+++ b/lib/git_ops/git.ex
@@ -55,6 +55,14 @@ defmodule GitOps.Git do
     end
   end
 
+  @spec tag_exists?(Git.Repository.t(), String.t()) :: boolean()
+  def tag_exists?(repo, tag) do
+    case Git.rev_parse(repo, ["--verify", "refs/tags/#{tag}"]) do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+
   @spec get_commit_info(Git.Repository.t(), String.t() | :all) :: [commit_info()]
   def get_commit_info(repo, since_tag \\ :all) do
     format = "--format=%H--hash--%B--message--%an--author--%ae--gitops--"

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -202,6 +202,15 @@ defmodule Mix.Tasks.GitOps.Release do
           GitOps.Version.last_valid_non_rc_version(tags, prefix)
         end
 
+      unless Git.tag_exists?(repo, tag) do
+        Mix.raise("""
+        The tag #{tag} was found in the tag list but does not exist locally.
+        This can happen when tags have not been fetched from the remote.
+
+        Run `git fetch --tags` and try again.
+        """)
+      end
+
       commit_info = Git.get_commit_info(repo, tag)
       commits_for_version = Enum.map(commit_info, & &1.message)
       authors = Enum.map(commit_info, &{&1.author_name, &1.author_email})

--- a/test/git_test.exs
+++ b/test/git_test.exs
@@ -50,4 +50,19 @@ defmodule GitOps.Test.GitTest do
       assert result == []
     end
   end
+
+  describe "tag_exists?/2" do
+    setup do
+      repo = Git.init!(".")
+      %{repo: repo}
+    end
+
+    test "returns true for a tag that exists locally", %{repo: repo} do
+      assert Git.tag_exists?(repo, "0.1.0")
+    end
+
+    test "returns false for a tag that does not exist locally", %{repo: repo} do
+      refute Git.tag_exists?(repo, "v999.999.999-nonexistent")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `GitOps.Git.tag_exists?/2` which uses `git rev-parse --verify refs/tags/<tag>` to check whether a tag exists locally
- Before generating the changelog, verifies that the previous version's tag is actually present in the local repo
- If the tag is missing, raises a clear error directing the user to run `git fetch --tags`

Closes #65

## Test plan

- [x] Added unit tests for `tag_exists?/2` (true/false cases)
- [x] Existing release and git tests pass
- [ ] Manual test: delete a local tag with `git tag -d <tag>`, run `mix git_ops.release`, confirm it aborts with the expected error