### PR TITLE
fix(GitHub): exclude organisations from user search response

### DIFF
--- a/lib/git_ops/github.ex
+++ b/lib/git_ops/github.ex
@@ -39,7 +39,7 @@ defmodule GitOps.GitHub do
     if email do
       case Req.get("#{GitOps.Config.github_api_base_url()}/search/users",
              headers: github_headers(),
-             params: [q: "#{email} in:email", per_page: 2]
+             params: [q: "#{email} in:email type:user", per_page: 2]
            ) do
         {:ok, %Req.Response{status: 200, body: %{"items" => [first_user | _]}}} ->
           {:ok,


### PR DESCRIPTION
### Contributor checklist
- [X] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

