### PR TITLE
Add `managed_files` config for updating arbitrary files on release

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ config :git_ops,
   # Instructs the tool to manage the version in your README.md
   # Pass in `true` to use `"README.md"` or a string to customize
   manage_readme_version: "README.md",
+  # Manage an arbitrary list of files during release.
+  # See "Managing additional files" below for details.
+  managed_files: [
+    {"apps/my_app/mix.exs", :mix},
+    {"README.md", :string}
+  ],
   version_tag_prefix: "v"
 ```
 
@@ -136,6 +142,33 @@ Most project readmes have a line like this that would ideally remain up to date:
 You can keep that number up to date via `manage_readme_version`, which accepts
 `true` for `README.md` or a string pointing to some other path relative to your
 project root.
+
+## Managing additional files
+
+For projects that need to update version strings in multiple files (e.g. poncho
+apps with several `mix.exs` files), use the `managed_files` option:
+
+```elixir
+config :git_ops,
+  managed_files: [
+    {"apps/my_app/mix.exs", :mix},
+    {"apps/my_other_app/mix.exs", :mix},
+    {"README.md", :string},
+    {"package.json", fn v -> "\"version\": \"#{v}\"" end, fn v -> "\"version\": \"#{v}\"" end}
+  ]
+```
+
+Each entry is a tuple describing a file and how to find/replace the version
+string within it:
+
+- `{path, :mix}` — replaces `@version "x.y.z"` (same pattern as `manage_mix_version?`)
+- `{path, :string}` — replaces `"~> x.y.z"` (same pattern as `manage_readme_version`)
+- `{path, replace_fn, pattern_fn}` — custom functions that each take a version
+  string and return the text to find/replace
+
+The `managed_files` list is merged with any files contributed by
+`manage_mix_version?` and `manage_readme_version`, so you can use all three
+options together or migrate to `managed_files` entirely.
 
 ## Using this with open source projects
 

--- a/lib/git_ops/config.ex
+++ b/lib/git_ops/config.ex
@@ -118,6 +118,48 @@ defmodule GitOps.Config do
 
   def prefix, do: Application.get_env(:git_ops, :version_tag_prefix) || ""
 
+  def managed_files do
+    explicit = Application.get_env(:git_ops, :managed_files, [])
+
+    mix_version_files =
+      if manage_mix_version?() do
+        source = mix_project().module_info()[:compile][:source] |> to_string()
+        [{source, :mix}]
+      else
+        []
+      end
+
+    readme_files =
+      case manage_readme_version() do
+        false ->
+          []
+
+        readme_config ->
+          readme_config
+          |> List.wrap()
+          |> Enum.map(fn
+            {_path, _replace, _pattern} = tuple -> tuple
+            path when is_binary(path) -> {path, :string}
+          end)
+      end
+
+    (mix_version_files ++ readme_files ++ explicit)
+    |> Enum.map(&desugar_managed_file/1)
+  end
+
+  defp desugar_managed_file({path, :mix}) do
+    {path, fn v -> "@version \"#{v}\"" end, fn v -> "@version \"#{v}\"" end}
+  end
+
+  defp desugar_managed_file({path, :string}) do
+    {path, fn v -> ", \"~> #{v}\"" end, fn v -> ", \"~> #{v}\"" end}
+  end
+
+  defp desugar_managed_file({_path, replace, pattern} = tuple)
+       when is_function(replace, 1) and is_function(pattern, 1) do
+    tuple
+  end
+
   defp truthy?(nil), do: false
   defp truthy?(false), do: false
   defp truthy?(_), do: true

--- a/lib/git_ops/version_replace.ex
+++ b/lib/git_ops/version_replace.ex
@@ -3,34 +3,16 @@ defmodule GitOps.VersionReplace do
   Functions that handle the logic behind replacing the version in related files.
   """
 
-  @spec update_mix_project(module, String.t(), String.t()) :: String.t() | {:error, :bad_replace}
-  def update_mix_project(mix_project, current_version, new_version, opts \\ []) do
-    file = mix_project.module_info()[:compile][:source]
-
-    update_file(file, "@version \"#{current_version}\"", "@version \"#{new_version}\"", opts)
-  end
-
-  @spec update_readme(
-          String.t()
-          | {String.t(), fun :: (String.t() -> String.t()), fun :: (String.t() -> String.t())},
+  @spec update_managed_file(
+          {String.t(), (String.t() -> String.t()), (String.t() -> String.t())},
           String.t(),
-          String.t()
+          String.t(),
+          keyword()
         ) :: String.t() | {:error, :bad_replace}
-  def update_readme(readme, current_version, new_version, opts \\ [])
-
-  def update_readme({readme, replace, pattern}, current_version, new_version, opts)
+  def update_managed_file({file, replace, pattern}, current_version, new_version, opts \\ [])
       when is_function(replace, 1) and is_function(pattern, 1) do
-    update_file(readme, replace.(current_version), pattern.(new_version), opts)
-  end
-
-  def update_readme(readme, current_version, new_version, opts) do
-    update_file(readme, ", \"~> #{current_version}\"", ", \"~> #{new_version}\"", opts)
-  end
-
-  defp update_file(file, replace, pattern, opts) do
     contents = File.read!(file)
-
-    new_contents = String.replace(contents, replace, pattern)
+    new_contents = String.replace(contents, replace.(current_version), pattern.(new_version))
 
     if new_contents == contents do
       {:error, :bad_replace}

--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -233,40 +233,26 @@ defmodule Mix.Tasks.GitOps.Release do
 
   defp create_and_display_changes(current_version, new_version, changelog_changes, opts) do
     changelog_file = Config.changelog_file()
-    mix_project_module = Config.mix_project()
-    readme = Config.manage_readme_version()
 
     Mix.shell().info("Your new version is: #{new_version}\n")
 
-    mix_project_changes =
-      if Config.manage_mix_version?() do
-        VersionReplace.update_mix_project(
-          mix_project_module,
-          current_version,
-          new_version,
-          opts
-        )
-      end
-
-    readme_changes =
-      readme
-      |> List.wrap()
-      |> Enum.reject(&(&1 == false))
-      |> Enum.map(fn readme ->
-        {readme, VersionReplace.update_readme(readme, current_version, new_version, opts)}
+    managed_file_changes =
+      Config.managed_files()
+      |> Enum.map(fn {path, _replace, _pattern} = managed_file ->
+        {path,
+         VersionReplace.update_managed_file(managed_file, current_version, new_version, opts)}
       end)
 
     if opts[:dry_run] do
       "Below are the contents of files that will change.\n"
       |> append_changes_to_message(changelog_file, changelog_changes)
-      |> add_readme_changes(readme_changes)
-      |> append_changes_to_message(mix_project_module, mix_project_changes)
+      |> add_managed_file_changes(managed_file_changes)
       |> Mix.shell().info()
     end
   end
 
-  defp add_readme_changes(message, readme_changes) do
-    Enum.reduce(readme_changes, message, fn {file, changes}, message ->
+  defp add_managed_file_changes(message, managed_file_changes) do
+    Enum.reduce(managed_file_changes, message, fn {file, changes}, message ->
       append_changes_to_message(message, file, changes)
     end)
   end

--- a/test/version_replace_test.exs
+++ b/test/version_replace_test.exs
@@ -22,6 +22,18 @@ defmodule GitOps.Test.VersionReplaceTest do
     """
   end
 
+  def mix_contents(version) do
+    """
+    defmodule MyApp.MixProject do
+      @version "#{version}"
+
+      def project do
+        [version: @version]
+      end
+    end
+    """
+  end
+
   def package_json_contents(version) do
     """
     {
@@ -32,54 +44,49 @@ defmodule GitOps.Test.VersionReplaceTest do
 
   setup do
     readme = "TEST_README.md"
+    mix_file = "TEST_MIX.exs"
+    package_json = "package.json"
     version = "0.1.1"
 
-    readme_contents = readme_contents(version)
-
-    File.write!(readme, readme_contents)
-
-    package_json = "package.json"
+    File.write!(readme, readme_contents(version))
+    File.write!(mix_file, mix_contents(version))
     File.write!(package_json, package_json_contents(version))
 
     on_exit(fn ->
       File.rm!(readme)
+      File.rm!(mix_file)
       File.rm!(package_json)
     end)
 
-    %{readme: readme, package_json: package_json, version: version}
+    %{readme: readme, mix_file: mix_file, package_json: package_json, version: version}
   end
 
-  test "that README gets written to properly", context do
-    readme = context.readme
-    version = context.version
-    new_version = "1.0.0"
-
-    VersionReplace.update_readme(readme, version, new_version)
-
-    assert File.read!(readme) == readme_contents(new_version)
+  test "string-style replacement updates README properly", context do
+    managed_file = {context.readme, fn v -> ", \"~> #{v}\"" end, fn v -> ", \"~> #{v}\"" end}
+    VersionReplace.update_managed_file(managed_file, context.version, "1.0.0")
+    assert File.read!(context.readme) == readme_contents("1.0.0")
   end
 
-  test "that README changes are not written with dry_run", context do
-    readme = context.readme
-    version = context.version
-    new_version = "1.0.0"
+  test "mix-style replacement updates version attribute", context do
+    managed_file =
+      {context.mix_file, fn v -> "@version \"#{v}\"" end, fn v -> "@version \"#{v}\"" end}
 
-    VersionReplace.update_readme(readme, version, new_version, dry_run: true)
-
-    assert File.read!(readme) == readme_contents(version)
+    VersionReplace.update_managed_file(managed_file, context.version, "1.0.0")
+    assert File.read!(context.mix_file) == mix_contents("1.0.0")
   end
 
-  test "custom replace/pattern", context do
-    readme = context.package_json
-    version = context.version
-    new_version = "1.0.0"
+  test "changes are not written with dry_run", context do
+    managed_file = {context.readme, fn v -> ", \"~> #{v}\"" end, fn v -> ", \"~> #{v}\"" end}
+    VersionReplace.update_managed_file(managed_file, context.version, "1.0.0", dry_run: true)
+    assert File.read!(context.readme) == readme_contents(context.version)
+  end
 
-    VersionReplace.update_readme(
-      {readme, fn v -> "\"version\": \"#{v}\"" end, fn v -> "\"version\": \"#{v}\"" end},
-      version,
-      new_version
-    )
+  test "custom replace/pattern functions", context do
+    managed_file =
+      {context.package_json, fn v -> "\"version\": \"#{v}\"" end,
+       fn v -> "\"version\": \"#{v}\"" end}
 
-    assert File.read!(readme) == package_json_contents(new_version)
+    VersionReplace.update_managed_file(managed_file, context.version, "1.0.0")
+    assert File.read!(context.package_json) == package_json_contents("1.0.0")
   end
 end


### PR DESCRIPTION
## Summary

- Adds a `managed_files` configuration option that allows updating version strings in an arbitrary list of files during release
- Each entry is a tuple: `{path, :mix}`, `{path, :string}`, or `{path, replace_fn, pattern_fn}` for custom replacements
- Useful for poncho apps or other projects that need to update multiple `mix.exs` files or other versioned files
- Existing `manage_mix_version?` and `manage_readme_version` options continue to work and are merged into the managed files list

## Example config

```elixir
config :git_ops,
  managed_files: [
    {"apps/my_app/mix.exs", :mix},
    {"apps/my_other_app/mix.exs", :mix},
    {"README.md", :string},
    {"package.json", fn v -> "\"version\": \"#{v}\"" end, fn v -> "\"version\": \"#{v}\"" end}
  ]
```

## Changes

- `GitOps.Config` — new `managed_files/0` that merges `manage_mix_version?`, `manage_readme_version`, and the new `managed_files` config into a single list of desugared `{path, replace_fn, pattern_fn}` tuples
- `GitOps.VersionReplace` — replaced `update_mix_project/4` and `update_readme/4` with a single `update_managed_file/4` that operates on desugared 3-tuples
- `Mix.Tasks.GitOps.Release` — unified the separate mix.exs and README handling into a single loop over managed files
- Updated tests and README documentation

## Test plan

- [x] All 115 existing tests pass
- [x] Compiler clean (warnings-as-errors)
- [x] Formatter clean
- [x] Credo clean (2 pre-existing issues only)
- [x] Dialyzer clean